### PR TITLE
add support for unsigned instance identity documents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,7 @@ COPY spec /opt/fake-ec2-metadata-service/spec/
 
 RUN apk update && \
     apk upgrade && \
-    apk add ruby ruby-io-console ruby-bundler && \
-    apk --update add ca-certificates ruby && \
-    rm -rf /var/cache/apk/* && \
+    apk --update --no-cache add ca-certificates ruby ruby-io-console ruby-bundler && \
     mkdir -p /opt/fake-ec2-metadata-service && \
     bundle install --deployment && \
     bundle exec rspec && \
@@ -20,4 +18,3 @@ RUN apk update && \
 
 EXPOSE 80
 ENTRYPOINT ["bundle", "exec", "/opt/fake-ec2-metadata-service/ec2-metadata-service.rb"]
-

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,10 @@ source 'https://rubygems.org'
 gem 'sinatra'
 gem 'sinatra-contrib'
 gem 'inifile', '~> 3.0'
+gem 'json_pure'
 
 group :test do
   gem 'rspec'
   gem 'rack-test'
+  gem 'rspec-json_expectations'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,50 +1,56 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.6.6)
-    diff-lcs (1.2.5)
+    backports (3.10.3)
+    diff-lcs (1.3)
     inifile (3.0.0)
-    multi_json (1.11.2)
-    rack (1.6.4)
-    rack-protection (1.5.3)
+    json_pure (2.1.0)
+    multi_json (1.12.2)
+    mustermann (1.0.1)
+    rack (2.0.3)
+    rack-protection (2.0.0)
       rack
-    rack-test (0.6.3)
-      rack (>= 1.0)
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.4)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    rack-test (0.8.2)
+      rack (>= 1.0, < 3)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
+      rspec-support (~> 3.7.0)
+    rspec-json_expectations (2.1.0)
+    rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
-    sinatra (1.4.6)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    sinatra-contrib (1.4.6)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
+    sinatra-contrib (2.0.0)
       backports (>= 2.0)
       multi_json
-      rack-protection
-      rack-test
-      sinatra (~> 1.4.0)
+      mustermann (~> 1.0)
+      rack-protection (= 2.0.0)
+      sinatra (= 2.0.0)
       tilt (>= 1.3, < 3)
-    tilt (2.0.1)
+    tilt (2.0.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   inifile (~> 3.0)
+  json_pure
   rack-test
   rspec
+  rspec-json_expectations
   sinatra
   sinatra-contrib
 
 BUNDLED WITH
-   1.10.6
+   1.13.4


### PR DESCRIPTION
  This works because for certain things (like region detection) the AWS
  SDKs don't check the signature of the identity document. Since we don't
  have the AWS private key, we have no way of returning a signed document.